### PR TITLE
Made discord.js messageembed style for option settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ const client = new Discord.Client(); // Create client
 const hangman = new HangmanGame({
   title: 'Hangman', // Title of the embed while displaying the game. Default: Hangman
   color: 'RANDOM', // Color of the embed. Default: RANDOM
-  timestamp: true // Will set timestamp for embeds. Default: true
+  timestamp: true, // Will set timestamp for embeds. Default: true
+  gameOverTitle: 'Game Over' // Will set the embed title of the game over embed. Default: 'Game Over'
 });
 
 // or
@@ -27,6 +28,7 @@ const hangman = new HangmanGame()
   .setEmbedTitle('Hangman') // Will set embed title
   .setEmbedColor('RANDOM') // Will set embed color
   .setTimestamp() // Will set timestamp for your embed!
+  .setGameOverTitle('Game Over') // Will set the embed title of the game over embed!
 
 // Config
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ const hangman = new HangmanGame({
   timestamp: true // Will set timestamp for embeds. Default: true
 });
 
+// or
+const hangman = new HangmanGame()
+  .setEmbedTitle('Hangman') // Will set embed title
+  .setEmbedColor('RANDOM') // Will set embed color
+  .setTimestamp() // Will set timestamp for your embed!
+
 // Config
 
 client.config = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 interface optionType{
   title?: string,
   color?: string,
+  gameOverTitle?: string,
   timestamp?: boolean
 }
 
@@ -21,8 +22,9 @@ class HangmanGame{
   public waitForReaction(): any;
   
   public setTimestamp(): void;
-  public setEmbedColor(color: string): void;
-  public setEmbedTitle(title: string): void;
+  public setColor(color: string): void;
+  public setTitle(title: string): void;
+  public setGameOverTitle(title: string): void;
 }
 
 export default HangmanGame

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,10 @@ class HangmanGame{
   public gameOver(win: any): any;
   public getDescription(): string;
   public waitForReaction(): any;
+  
+  public setTimestamp(): void;
+  public setEmbedColor(color: string): void;
+  public setEmbedTitle(title: string): void;
 }
 
 export default HangmanGame

--- a/index.js
+++ b/index.js
@@ -32,8 +32,8 @@ class HangmanGame {
 
  
         const embed = new Discord.MessageEmbed()
-            .setColor(this.options.color ? this.options.color : 'RANDOM')
-            .setTitle(this.options.title ? this.options.title : 'Hangman')
+            .setColor(this.options.color || 'RANDOM')
+            .setTitle(this.options.title || 'Hangman')
             .setDescription(this.getDescription())
             .addField('Letters Guessed', '\u200b')
             .addField("React to this message using the emojis that look like letters", "\u200b")
@@ -67,8 +67,8 @@ class HangmanGame {
 
         if (this.inGame) {
             const editEmbed = new Discord.MessageEmbed()
-                .setColor(this.options.color ? this.options.color : 'RANDOM')
-                .setTitle(this.options.title ? this.options.title : 'Hangman')
+                .setColor(this.options.color || 'RANDOM')
+                .setTitle(this.options.title || 'Hangman')
                 .setDescription(this.getDescription())
                 .addField('Letters Guessed', this.guesssed.length == 0 ? '\u200b' : this.guesssed.join(" "))
                 .addField("React to this message using the emojis that look like letters", "\u200b")
@@ -83,8 +83,8 @@ class HangmanGame {
     gameOver(win) {
         this.inGame = false;
         const editEmbed = new Discord.MessageEmbed()
-            .setColor(this.options.color ? this.options.color : 'RANDOM')
-            .setTitle(this.options.title ? this.options.title : 'Hangman')
+            .setColor(this.options.color || 'RANDOM')
+            .setTitle(this.options.gameOverTitle || 'Game Over')
             .setDescription((win ? "You Wins!" : "You losses") + "\n\nThe Word was:\n" + this.word)
         
         if(this.options.timestamp) embed.setTimestamp()
@@ -124,8 +124,9 @@ class HangmanGame {
     }
     
     setTimestamp(){ this.options.timestamp = true }
-    setEmbedTitle(title){ this.options.title = title || 'Hangman' }
-    setEmbedColor(color){ this.options.color = color || 'RANDOM' }
+    setTitle(title){ this.options.title = title || 'Hangman' }
+    setColor(color){ this.options.color = color || 'RANDOM' }
+    setGameOverTitle(title){ this.options.gameOverTitle = title || 'Game Over' }
 }
 
 module.exports = HangmanGame;

--- a/index.js
+++ b/index.js
@@ -15,15 +15,14 @@ class HangmanGame {
     constructor(options) {
         this.gameEmbed = null;
         this.inGame = false;
-        this.word = "";
+        this.word = ""; 
         this.guesssed = [];
         this.wrongs = 0;
-        this.this.options = this.options
+        this.options = this.options;
     }
 
     newGame(msg) {
-        if (this.inGame)
-            return;
+        if (this.inGame) return;
 
         this.inGame = true;
         this.word = possible_words[Math.floor(Math.random() * possible_words.length)].toUpperCase();

--- a/index.js
+++ b/index.js
@@ -12,13 +12,14 @@ const letterEmojisMap = {
 }
 
 class HangmanGame {
-    constructor(options) {
+
+    constructor(options={}) {
         this.gameEmbed = null;
         this.inGame = false;
         this.word = ""; 
         this.guesssed = [];
         this.wrongs = 0;
-        this.options = this.options;
+        this.options = options;
     }
 
     newGame(msg) {
@@ -121,6 +122,10 @@ class HangmanGame {
                 this.gameOver(false);
             });
     }
+    
+    setTimestamp(){ this.options.timestamp = true }
+    setEmbedTitle(title){ this.options.title = title || 'Hangman' }
+    setEmbedColor(color){ this.options.color = color || 'RANDOM' }
 }
 
 module.exports = HangmanGame;


### PR DESCRIPTION
Updated options with a new option named `gameOverTitle` with discordjs message embed option setting style

**New Docs:**
```js
const Discord = require('discord.js'); // Require discord.js
const HangmanGame = require('hangcord'); // Require HangmanGame
const client = new Discord.Client(); // Create client

const hangman = new HangmanGame({
  title: 'Hangman', // Title of the embed while displaying the game. Default: Hangman
  color: 'RANDOM', // Color of the embed. Default: RANDOM
  timestamp: true, // Will set timestamp for embeds. Default: true
  gameOverTitle: 'Game Over' // Will set the embed title of the game over embed. Default: 'Game Over'
});

// or
const hangman = new HangmanGame()
  .setEmbedTitle('Hangman') // Will set embed title
  .setEmbedColor('RANDOM') // Will set embed color
  .setTimestamp() // Will set timestamp for your embed!
  .setGameOverTitle('Game Over') // Will set the embed title of the game over embed!
```

And yes updated docs in readme.md and typings in index.d.ts 
Make sure to check for errors